### PR TITLE
Add link for configuring NuGet.config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can download the .NET Core SDK as either an installer (MSI, PKG) or a zip (z
 
 **Note:** Be aware that the following installers are the **latest bits**. If you
 want to install the latest released versions, check out the [preceding section](#looking-for-v2-of-the-net-core-tooling).
-With development builds, internal NuGet feeds are necessary for some scenarios (for example, to acquire the runtime pack for self-contained apps). You can use the following NuGet.config to configure these feeds.
+With development builds, internal NuGet feeds are necessary for some scenarios (for example, to acquire the runtime pack for self-contained apps). You can use the following NuGet.config to configure these feeds. See the following document [Configuring NuGet behavior](https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior) for more information on where to modify your NuGet.config to apply the changes.
 > Example:
 
 **For .NET 6 builds**


### PR DESCRIPTION
The documentation explains how to configure your nuget feeds by changing your NuGet.config file but doesn't explain where the file is located. Added a link to microsoft docs Configuring NuGet behavior to the readme.md
